### PR TITLE
Changed access to `public` for AbstractRequest::build(), because of n…

### DIFF
--- a/src/AbstractRequest.php
+++ b/src/AbstractRequest.php
@@ -115,7 +115,7 @@ abstract class AbstractRequest implements RequestInterface
         return $this->query;
     }
 
-    protected function build()
+    public function build()
     {
         if ($this->isBuilt === null) {
             if (!empty($this->query)) {


### PR DESCRIPTION
…eed to build the fake request for PACT